### PR TITLE
Saml updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,7 @@ latexpdfja:
 	@echo "pdflatex finished; the PDF files are in $(BUILDDIR)/latex."
 
 livehtml:
-	sphinx-autobuild -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
+	sphinx-autobuild -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html/rest
 
 text:
 	$(SPHINXBUILD) -b text $(ALLSPHINXOPTS) $(BUILDDIR)/text

--- a/source/004_accnt_mgmt.rst
+++ b/source/004_accnt_mgmt.rst
@@ -22,11 +22,10 @@ For more detailed information about the Directory resource, please see the :ref:
 
 Types of Directories
 ^^^^^^^^^^^^^^^^^^^^
-Stormpath supports three types of Directories:
+Stormpath supports two types of Directories:
 
-1. Natively-hosted Cloud Directories that originate in Stormpath
-2. Mirror Directories that act as secure replicas of existing LDAP user directories outside of Stormpath, for example those on Active Directory servers.
-3. Social Directories that pull in account information from four sites that support social login: Google, Facebook, Github and LinkedIn.
+1. Natively-hosted **Cloud Directories** that originate in Stormpath
+2. **Mirror Directories** that act as secure replicas of existing user directories outside of Stormpath, for example those on LDAP Directory servers, on Facebook and other websites, as well as in Identity Providers that support SAML.
    
 You can add as many Directories of each type as you require.
 
@@ -34,7 +33,7 @@ You can add as many Directories of each type as you require.
 
   Multiple Directories are a more advanced feature of Stormpath. If you have one or more applications that all access the same Accounts, you usually only need a single Directory, and you do not need to be concerned with creating or managing multiple Directories.
 
-  If however, your application(s) needs to support login for external third-party accounts like those in Active Directory, or you have more complex account segmentation needs, Directories will be a powerful tool to manage your application's user base.
+  If however, your application needs to support login for :ref:`multiple external third-party accounts <supporting-multiple-dirs>`, or you have more complex account segmentation needs, Directories will be a powerful tool to manage your application's user base. 
 
 .. _about-cloud-dir:
 
@@ -63,7 +62,7 @@ Would yield the following response:
 .. code-block:: HTTP 
 
   HTTP/1.1 201 Created
-  Location: https://api.stormpath.com/v1/directories/bckhcGMXQDujIXpbCDRb2Q
+  Location: https://api.stormpath.com/v1/directories/2SKhstu8PlaekcaEXampLE
   Content-Type: application/json;charset=UTF-8
 
   {
@@ -85,12 +84,37 @@ Would yield the following response:
     }
   }
 
-.. _about-mirror-dir:
-
 Mirror Directories
-^^^^^^^^^^^^^^^^^^ 
+^^^^^^^^^^^^^^^^^^
 
-Mirror Directories are a big benefit to Stormpath customers who need LDAP directory accounts to be able to securely log in to public web applications without breaking corporate firewall policies. Here is how they work:
+**Mirror Directories** are all Directories that pull-in data from external user databases. Currently this encompasses:
+
+- LDAP Directories, including Active Directory
+- Social Directories, such as Facebook and GitHub
+- SAML-enabled Identity Provider Directories, such as Salesforce and OneLogin
+
+For all Mirror Directories, since the relationship with the outside directory is read-only, the remote directory is still the "system of record".
+
+.. _supporting-multiple-dirs:
+
+**Supporting Multiple Mirror Directories**
+
+It is possible to use different kinds of Directories simultaneously, to allow users to log-in with multiple external systems at the same time. For example, if you wanted to enable logging-in with Facebook, LinkedIn, and Salesforce, this would require a separate Mirror Directory for each one. 
+
+If multiple Directories are desired, we recommend that you create a separate "master" Directory that allows for a unified user identity. This master Directory would link all the Accounts in Mirror Directories with a master Account in a master Directory. This offers a few benefits:
+
+1. You can maintain one Directory that has all your user Accounts, retaining globally unique canonical identities across your application
+
+2. You are able to leverage your own Groups in the master Directory. Remember, most data in a Mirror Directory is read-only, meaning you cannot create your own Groups in it, only read the Groups (if any) synchronized from the external directory. 
+
+3. Keep a user’s identity alive even after they've left your customer's organization and been deprovisioned in the external user directory. This is valuable in a SaaS model where the user is loosely coupled to an organization. Contractors and temporary workers are good examples.
+
+.. _about-ldap-dir:
+
+LDAP Directories
+""""""""""""""""
+
+LDAP Directories are a big benefit to Stormpath customers who need LDAP directory accounts to be able to securely log in to public web applications without breaking corporate firewall policies. Here is how they work:
 
 - After creating an LDAP Directory in Stormpath, you download a Stormpath Agent. This is a simple standalone software application that you install behind the corporate firewall so it can communicate directly with the LDAP server.
 - You configure the agent via LDAP filters to view only the accounts that you want to expose to your Stormpath-enabled applications.
@@ -98,75 +122,63 @@ Mirror Directories are a big benefit to Stormpath customers who need LDAP direct
 - The synchronized user Accounts and Groups appear in the Stormpath Directory. The Accounts will be able to log in to any Stormpath-enabled application that you assign.
 - When the Agent detects local LDAP changes, additions or deletions to these specific Accounts or Groups, it will automatically propagate those changes to Stormpath to be reflected by your Stormpath-enabled applications.
   
-User Accounts and Groups in mirrored directories are automatically deleted when any of the following things happen:
+User Accounts and Groups in LDAP directories are automatically deleted when any of the following things happen:
 
 - The original object is deleted from the LDAP directory service.
 - The original LDAP object information no longer matches the account filter criteria configured for the agent.
 - The LDAP directory is deleted.
 
-The big benefit is that your Stormpath-enabled applications still use the same convenient REST+JSON API – they do not need to know anything about things like LDAP or legacy connection protocols.
+The big benefit is that your Stormpath-enabled applications still use the same convenient REST API – they do not need to know anything about things like LDAP or legacy connection protocols.
 
-.. _modeling-mirror-dirs:
+.. _modeling-ldap-dirs:
 
-Modeling Mirror Directories
-"""""""""""""""""""""""""""
+Modeling LDAP Directories
++++++++++++++++++++++++++++
 
-If your Application is going to have an LDAP integration, it will need to support multiple Directories — one Mirror Directory for each LDAP integration.
+As Mirror Directories, LDAP Directories must have the same structure as the external LDAP directories that they are synchronizing with. 
 
-In this scenario, we recommend linking each Account in a LDAP Mirror Directory with a master Account in a master Directory. This offers a few benefits:
+The Stormpath Agent (see :ref:`ref-ldap-agent`) is regularly updating its LDAP Directory and sometimes adding new user Accounts and/or Groups. Because this data can be quite fluid, we recommend initiating all provisioning, linking, and synchronization on a successful login attempt of the Account in the LDAP Directory. This means that the master Directory would start off empty, and would then gradually become populated every time a user logged in.
 
-1. You can maintain one Directory that has all your user Accounts, retaining globally unique canonical identities across your application
+For more information on how to this works, please see :ref:`ldap-dir-authn`.
 
-2. You are able to leverage your own Groups in the master Directory. Remember, most data in a Mirror Directory is read-only, meaning you cannot create your own Groups in it, only read the Groups synchronized from Active Directory and LDAP
+.. _make-ldap-dir:
 
-3. Keep a user’s identity alive even after they've left your customer's organization and been deprovisioned in AD/LDAP. This is valuable in a SaaS model where the user is loosely coupled to an organization. Contractors and temporary workers are good examples.
+How to Make a LDAP Directory
+++++++++++++++++++++++++++++
 
-The Stormpath Agent (see :ref:`ref-ldap-agent`) is regularly updating its Mirror Directory and sometimes adding new user Accounts. Because this data can be quite fluid, we recommend initiating all provisioning, linking, and synchronization on a successful login attempt of the Account in the Mirror Directory. This means that the master Directory would start off empty, and would then gradually become populated every time a user logged in.
-
-For more information on how to this works, please see :ref:`mirror-dir-authn`.
-
-.. _make-mirror-dir:
-
-How to Make a Mirror Directory
-""""""""""""""""""""""""""""""
-
-Presently, Mirror Directories can be made via the Stormpath Admin Console, or using the REST API. If you'd like to do it with the Admin Console, please see `the Directory Creation section of the Admin Console Guide <http://docs.stormpath.com/console/product-guide/#create-a-directory>`_. For more information about creating them using REST API, please see :ref:`mirror-dir-authn`. 
+Presently, LDAP Directories can be made via the Stormpath Admin Console, or using the REST API. If you'd like to do it with the Admin Console, please see `the Directory Creation section of the Admin Console Guide <http://docs.stormpath.com/console/product-guide/#create-a-directory>`_. For more information about creating them using REST API, please see :ref:`ldap-dir-authn`. 
 
 .. _about-social-dir:
     
 Social Directories
-^^^^^^^^^^^^^^^^^^
+""""""""""""""""""
 
-Stormpath works with user Accounts pulled from social login providers (currently Google, Facebook, Github, and LinkedIn) in a way very similar to the way it works with user Accounts from LDAP servers. These external Identity Providers (IdPs) are modeled as Stormpath Directories, much like Mirror Directories. The difference is that, while Mirror Directories always come with an Agent that takes care of synchronization, Social Directories have an associated **Provider** resource. This resource contains the information required by the social login site to work with their site (e.g. the App ID for your Google application or the App Secret).
+Stormpath works with user Accounts pulled from social login providers (currently Google, Facebook, Github, and LinkedIn) in a way very similar to the way it works with user Accounts from LDAP servers. These external social login providers are modeled as Stormpath Directories, much like LDAP Directories. The difference is that, while LDAP Directories always come with an Agent that takes care of synchronization, Social Directories have an associated **Provider** resource. This resource contains the information required by the social login site to work with their site (e.g. the App ID for your Google application).
 
 Stormpath also simplifies the authorization process by doing things like automating Google's access token exchange flow. All you do is POST the authorization code from the end-user and Stormpath returns a new or updated user Account, along with the Google access token which you can use for any further API calls. 
 
 Modeling Social Directories
-"""""""""""""""""""""""""""
+++++++++++++++++++++++++++++
 
-Modeling your users who authorize via Social Login could be accomplished by creating a Directory resource for each social provider that you want to support, along with one master Directory for your application. For more about how these Directories are provisioned, please see :ref:`non-cloud-login`.
-
-.. note::
-
-  For both Mirror and Social Directories, since the relationship with the outside directory is read-only, the remote directory is still the "system of record".
+Modeling your users who authorize via Social Login is by necessity very simple, since social login providers do not include the concept of "groups" of users in the same way that LDAP directories do. The only thing that you really have to do as an app developer is create a Directory resource for each social provider that you want to support. As mentioned :ref:`above <supporting-multiple-dirs>`, if you want to support multiple Directories then you may also want to create a master Directory for your application. For more about how Social Directories are provisioned, please see :ref:`mirror-login`.
 
 How to Make a Social Directory
-""""""""""""""""""""""""""""""
+++++++++++++++++++++++++++++++
 
 Presently, Social Directories can be made via the Stormpath Admin Console or using REST API. For more information about creating them with the Admin Console please see the `Directories section of the Stormpath Admin Console Guide <http://docs.stormpath.com/console/product-guide/#create-a-directory>`_. For more information about creating them using REST API, please see :ref:`social-authn`. 
 
 .. _about-saml-dirs:
 
 SAML Directories 
-^^^^^^^^^^^^^^^^
+""""""""""""""""
 
-In addition to Social Login and LDAP, Stormpath also allows your users to log-in with SAML Identity Providers. Just like with Social Directories, SAML Directories are configured via an associated Provider resource that contains the configuration information for the Identity Provider. 
+In addition to Social Login and LDAP, Stormpath also allows your users to log-in with SAML Identity Providers. Just like with Social Directories, SAML Directories are configured via an associated Provider resource that contains the configuration information for the Identity Provider.
 
 Modeling SAML Directories 
-"""""""""""""""""""""""""
++++++++++++++++++++++++++
 
 How to Make a SAML Directory 
-""""""""""""""""""""""""""""
+++++++++++++++++++++++++++++
 
 .. _group-mgmt:
 

--- a/source/004_accnt_mgmt.rst
+++ b/source/004_accnt_mgmt.rst
@@ -119,7 +119,7 @@ In this scenario, we recommend linking each Account in a LDAP Mirror Directory w
 
 2. You are able to leverage your own Groups in the master Directory. Remember, most data in a Mirror Directory is read-only, meaning you cannot create your own Groups in it, only read the Groups synchronized from Active Directory and LDAP
 
-3. Keep a user’s identity alive even after they've left your customer's organization and been deprovisioned in AD/LDAP. This is valuable in a SaaS model where the user is loosely coupled to an organization. Contractors and temporary workers are good examples
+3. Keep a user’s identity alive even after they've left your customer's organization and been deprovisioned in AD/LDAP. This is valuable in a SaaS model where the user is loosely coupled to an organization. Contractors and temporary workers are good examples.
 
 The Stormpath Agent (see :ref:`ref-ldap-agent`) is regularly updating its Mirror Directory and sometimes adding new user Accounts. Because this data can be quite fluid, we recommend initiating all provisioning, linking, and synchronization on a successful login attempt of the Account in the Mirror Directory. This means that the master Directory would start off empty, and would then gradually become populated every time a user logged in.
 
@@ -154,6 +154,19 @@ How to Make a Social Directory
 """"""""""""""""""""""""""""""
 
 Presently, Social Directories can be made via the Stormpath Admin Console or using REST API. For more information about creating them with the Admin Console please see the `Directories section of the Stormpath Admin Console Guide <http://docs.stormpath.com/console/product-guide/#create-a-directory>`_. For more information about creating them using REST API, please see :ref:`social-authn`. 
+
+.. _about-saml-dirs:
+
+SAML Directories 
+^^^^^^^^^^^^^^^^
+
+In addition to Social Login and LDAP, Stormpath also allows your users to log-in with SAML Identity Providers. Just like with Social Directories, SAML Directories are configured via an associated Provider resource that contains the configuration information for the Identity Provider. 
+
+Modeling SAML Directories 
+"""""""""""""""""""""""""
+
+How to Make a SAML Directory 
+""""""""""""""""""""""""""""
 
 .. _group-mgmt:
 

--- a/source/005_auth_n.rst
+++ b/source/005_auth_n.rst
@@ -94,12 +94,12 @@ You can map multiple Account Stores to an Application, but only one is required 
 
 .. _non-cloud-login:
 
-How Login Works with Mirrored and Social Directories 
+How Login Works with Non-Cloud Directories 
 """"""""""""""""""""""""""""""""""""""""""""""""""""
 
-For both :ref:`Mirrored <about-mirror-dir>` and :ref:`Social<about-social-dir>` Directories, Stormpath has a default behavior that links the Mirror/Social Directories with corresponding "master" Directories. 
+Non-Cloud Directories, like :ref:`Mirrored <about-mirror-dir>`, :ref:`Social<about-social-dir>`, and :ref:`SAML <saml-authn>` Directories, Stormpath suggests a best practice that links the Mirror/Social Directories with corresponding "master" Directories. 
 
-The default Stormpath behavior is as a follows: a new user visits your site, and chooses something to log-in with their LDAP credentials, or social login like "Sign-in with Google". Once they log in using their social or LDAP credentials, if it doesn't already exist, a new user Account is created in your Mirror/Social Directory. After this Account is created, a search is performed inside the Application's master Directory for their email address, to see if they already exist in there. If the user Account is already in the master Directory, no action is taken. If the user Account is not found, a new one is created in the master Directory, and populated with the information pulled from the Google account. The customData resource for that Account is then used to store an ``href`` link to their Account in the Mirror/Social Directory. 
+Your application should follow a process similar to this: a new user visits your site, and chooses to log-in with their LDAP credentials, or social login like "Sign-in with Google". Once they log in, if an Account doesn't already exist, it is created in your Directory. After this Account is created, a search is performed inside the Application's master Directory for their email address, to see if they already exist in there. If the user Account is already in the master Directory, no action is taken. If the user Account is not found, a new one is created in the master Directory, and populated with the information pulled from the Google account. The customData resource for that Account is then used to store an ``href`` link to their Account in the Mirror/Social Directory. 
 
 .. code-block:: json 
 
@@ -1135,10 +1135,10 @@ Input the data you gathered in Step 1 above into your Directory's Provider resou
 
 .. _configure-sp-in-idp:
 
-Step 3: Configure Your Service Provider in Your Identity Provider 
+Step 3: Retrieve Your Service Provider Metadata
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Next you will have to configure your Stormpath-powered application as a Service Provider in your Identity Provider. 
+Next you will have to configure your Stormpath-powered application as a Service Provider in your Identity Provider. This means that you will need to retrieve the correct metadata from Stormpath. 
 
 In order to retrieve the required values, start by sending a GET to the Directory's Provider:
 
@@ -1227,6 +1227,11 @@ You will also need two other values, which will always be the same:
 
 - **SAML Request Binding:** Set to ``HTTP-Redirect``.
 - **SAML Response Binding:** Set to ``HTTP-Post``.
+
+Step 5: Configure Your Service Provider in Your Identity Provider 
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Log-in to your Identity Provider (Salesforce, OneLogin, etc) and enter the information you retrieved in the previous step into the relevant application configuration fields. The specific steps to follow here will depend entirely on what Identity Provider you use, and for more information you should consult your Identity Provider's SAML documentation. 
 
 Step 4: Configure Your Application
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/source/005_auth_n.rst
+++ b/source/005_auth_n.rst
@@ -92,37 +92,26 @@ As you can see, Stormpath tries to find the Account in the "Customers" Directory
 
 You can map multiple Account Stores to an Application, but only one is required to enable login for an Application. Mapping multiple Account Stores to an Application, as well as configuring their priority, allows you precise control over the Account populations that may log in to your Application.
 
-.. _non-cloud-login:
+.. _mirror-login:
 
-How Login Works with Non-Cloud Directories 
-""""""""""""""""""""""""""""""""""""""""""""""""""""
+How Login Works with Master Directories 
+"""""""""""""""""""""""""""""""""""""""
 
-Non-Cloud Directories, like :ref:`Mirrored <about-mirror-dir>`, :ref:`Social<about-social-dir>`, and :ref:`SAML <saml-authn>` Directories, Stormpath suggests a best practice that links the Mirror/Social Directories with corresponding "master" Directories. 
+If you require a number of Mirror Directories, then we recommend that you have a master Directory alongside them. Any login attempts should be directed to the Mirror Directory. If the attempt succeeds, your application should then perform a :ref:`search <about-search>` of the master Directory to see if there is an Account already there that links to this Account in the Mirror Directory. 
 
-Your application should follow a process similar to this: a new user visits your site, and chooses to log-in with their LDAP credentials, or social login like "Sign-in with Google". Once they log in, if an Account doesn't already exist, it is created in your Directory. After this Account is created, a search is performed inside the Application's master Directory for their email address, to see if they already exist in there. If the user Account is already in the master Directory, no action is taken. If the user Account is not found, a new one is created in the master Directory, and populated with the information pulled from the Google account. The customData resource for that Account is then used to store an ``href`` link to their Account in the Mirror/Social Directory. 
+If such an Account is already in the master Directory, no action is taken. If such an Account is not found, your application should create a new one in the master Directory, and populate it with the information pulled from the Account in the Mirror Directory. The customData resource for that master Account should then be used to store an ``href`` link to the Account in the Mirror Directory, for example:
 
 .. code-block:: json 
 
   {
     "customData": {
-      "accountLink": "https://api.stormpath.com/v1/accounts/3fLduLKlQu"
+      "accountLink": "https://api.stormpath.com/v1/accounts/3fLduLKlEx"
     }
   }
 
-If the user then chooses at some point to "Sign in with Facebook", then a similar process will occur, but this time with a link created to the user Account in the Facebook Directory. 
+If the user then chooses at some point to, for example, "Sign in with Facebook", then a similar process will occur, but this time with a link created to the user Account in the Facebook Directory. 
 
-.. code-block:: json 
-
-  {
-    "customData": {
-      "accountLinks": {
-          "Link1": "https://api.stormpath.com/v1/accounts/3fLduLKlQu",
-          "Link2": "https://api.stormpath.com/v1/accounts/X3rjfa4Ljd", 
-          "Link3": "https://api.stormpath.com/v1/accounts/a05Ghpjd30"
-      }
-  }
-
-This approach has two major benefits: It allows for a user to have one unified identity in your Application, regardless of how many social or LDAP identities they choose to log in with; this central identity can also be the central point that all authorization permissions (whether they be implicit or explicit) are then applied to.
+This mirror-master approach has two major benefits: It allows for a user to have one unified identity in your Application, regardless of how many external identities they choose to log in with; and this central identity can also be the central point that all authorization permissions (whether they be implicit or explicit) are then applied to.
 
 .. _managing-login:
 
@@ -940,26 +929,28 @@ Once the Access Token is gathered, you can send an HTTP POST:
 
 Stormpath will use the ``accessToken`` provided to retrieve information about your LinkedIn Account, then return a Stormpath Account. The HTTP Status code will tell you if the Account was created (HTTP 201) or if it already existed in Stormpath (HTTP 200). 
 
-.. _mirror-dir-authn:
+.. _ldap-dir-authn:
 
-5.4. Authenticating Against a Mirrored LDAP Directory
+5.4. Authenticating Against an LDAP Directory
 =====================================================
 
 .. contents:: 
   :local: 
   :depth: 2
 
-This section assumes that you are already familiar both with :ref:`how-login-works` and the concept of Stormpath :ref:`about-mirror-dir` as well as how they are :ref:`modeled <modeling-mirror-dirs>`. 
+This section assumes that you are already familiar both with :ref:`how-login-works` and the concept of Stormpath :ref:`LDAP Directories<about-ldap-dir>`. 
 
 Mirror Directories and LDAP 
 ---------------------------
 
-To recap: With LDAP integration, Stormpath is simply mirroring the canonical LDAP user directory, so it is recommended that you maintain a "master" Directory alongside your Mirror Directory. Furthermore, a successful user login is the recommended time to provision, link, and synchronize an Account in the Mirror Directory to your master Directory.
+To recap: With LDAP integration, Stormpath is simply mirroring the canonical LDAP user directory. If this fulfills your requirements, then the story ends here. However, if you need to support other kinds of login (and therefore other kinds of Directories) it is recommended that you maintain a "master" Directory alongside your Mirror Directory. For more about this, see :ref:`mirror-login` above.
 
-Step 1: Create a Mirror Directory
+The step-by-step process for setting-up LDAP login is as follows: 
+
+Step 1: Create an LDAP Directory
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-HTTP POST a new Directory resource to the ``/directories`` endpoint. This Directory will contain a :ref:`ref-provider` resource with ``providerId`` set to ``"ldap"``. This Provider resource will in turn contain an :ref:`ref-ldap-agent` object:
+HTTP POST a new Directory resource to the ``/directories`` endpoint. This Directory will contain a :ref:`ref-provider` resource with ``providerId`` set to ``ldap`` or ``ad``. This Provider resource will in turn contain an :ref:`ref-ldap-agent` object:
 
 .. code-block:: http
 
@@ -1047,7 +1038,7 @@ In Windows:
 
 In Unix:
 
-cd to your agent directory, for example /opt/stormpath/agent
+(cd to your agent directory, for example /opt/stormpath/agent)
 
 .. code-block:: bash 
 
@@ -1056,12 +1047,10 @@ cd to your agent directory, for example /opt/stormpath/agent
 
 The Agent will start synchronizing immediately, pushing the configured data to Stormpath. You will see the synchronized user Accounts and Groups appear in the Stormpath Directory, and the Accounts will be able to log in to any Stormpath-enabled application that you assign. When the Agent detects local changes, additions or deletions to the mirrored Accounts or Groups, it will automatically propagate those changes to Stormpath.
 
-Step 3: Map the Mirror Directory as an Account Store for Your Application
+Step 3: Map the LDAP Directory as an Account Store for Your Application
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Creating an Account Store Mapping between your new Mirror Directory and your Stormpath Application can be done through the REST API, as described in :ref:`create-asm`.
-
-From this point on, any time a user logs in to your Application, their Account will be provisioned into Stormpath, as detailed above in :ref:`non-cloud-login`.
+Creating an Account Store Mapping between your new LDAP Directory and your Stormpath Application can be done through the REST API, as described in :ref:`create-asm`.
 
 .. _saml-authn:
 

--- a/source/reference.rst
+++ b/source/reference.rst
@@ -2441,7 +2441,7 @@ For example, a Social Directory could be created for GitHub. This Directory woul
   
   * - ``providerId``
     - String
-    - ``stormpath`` (for a Cloud Directory); ``ad`` or ``ldap`` (for Mirror Directories); ``facebook``, ``google``, ``github`` or ``linkedin`` (for Social Directories); ``saml`` (for SAML Directories)
+    - ``stormpath`` (for a Cloud Directory); ``ad`` or ``ldap`` (for LDAP Directories); ``facebook``, ``google``, ``github`` or ``linkedin`` (for Social Directories); ``saml`` (for SAML Directories)
     - Specifies the type of Provider for the associated Directory.
   
   * - ``clientId``
@@ -2513,7 +2513,7 @@ For example, a Social Directory could be created for GitHub. This Directory woul
 LDAP Agent
 """"""""""
 
-:ref:`Mirror Directories <about-mirror-dir>` have an associated :ref:`Provider resource <ref-provider>` with either the ``ldap`` or ``ad`` ``providerId``. That Provider in turn contains an **Agent** resource. This Agent is what will scan your LDAP directory and map the accounts and groups in that directory to Stormpath Accounts and Groups.
+:ref:`LDAP Directories <about-ldap-dir>` have an associated :ref:`Provider resource <ref-provider>` with either the ``ldap`` or ``ad`` ``providerId``. That Provider in turn contains an **Agent** resource. This Agent is what will scan your LDAP directory and map the accounts and groups in that directory to Stormpath Accounts and Groups.
 
 An Agents collection may be accessed via its Resource URL:
 


### PR DESCRIPTION
- All non-cloud Directories are now called "Mirror Directories"
- Clarified How Login Works, and How Login Works with Master Directories
- Added information about SAML Directories to Accnt Mgmt chapter
