### PR TITLE
Create an account for an organization

### DIFF
--- a/source/reference.rst
+++ b/source/reference.rst
@@ -3886,7 +3886,7 @@ Because an Account is "owned" by a Directory, you can add it either directly thr
       - Optional Parameters 
       - Description
     
-    * - POST /v1/directories/$DIRECTORY_ID/accounts *or* /v1/applications/$APPLICATION_ID/accounts
+    * - POST /v1/directories/$DIRECTORY_ID/accounts *or* /v1/applications/$APPLICATION_ID/accounts *or* /v1/organizations/$ORGANIZATION_ID/accounts
       - Required: ``email``, ``password``, ``givenName``, ``surname``; Optional: ``username``, ``middleName``, ``status``, ``customData``
       - ``registrationWorkflowEnabled=false``, ``passwordFormat=mcf`` (see note below)
       - Creates a new Account resource.

--- a/source/reference.rst
+++ b/source/reference.rst
@@ -3875,7 +3875,7 @@ Account Operations
 Create an Account 
 ^^^^^^^^^^^^^^^^^
 
-Because an Account is "owned" by a Directory, you can add it either directly through the Directory that owns it, or indirectly via an Application that has that Directory as an Account Store:
+Because an Account is "owned" by a Directory, you can add it either directly through the Directory that owns it, or indirectly via an Application that has that Directory as an Account Store, or an Organization that is mapped to the Directory through a Group:
 
 .. list-table::
     :widths: 30 15 15 40


### PR DESCRIPTION
In the multi-tenancy chapter, it says the following:

> If at some future point you want to disable that tenant, all you have to do is remove the Account Store Mapping between that Organization and your Application, and the tenant’s users would no longer be able to log in.

This will only work if there is no direct mapping between application and directory, but only through `application-->organization-->(tenant)group-->directory`. Otherwise, users of an organisation will still be able to login, even after removing the `organization<->application` mapping, because that same user is also mapped through the directory.

To make this feasible, one would expect to be able to create accounts directly for an organisation, as opposed to a group or directory. To my surprise, this is actually possible, although it's not documented. This PR changes that.

I'd propose to also clarify this in the multi-tenancy chapter.
