### PR TITLE
Add external link to .NET API docs

### DIFF
--- a/source/_templates/layout.html
+++ b/source/_templates/layout.html
@@ -1,5 +1,16 @@
 {% extends "!layout.html" %}
 
+{% block menu %}
+  {{ super() }}
+
+  {% if language_slug == 'csharp' or language_slug == 'vbnet' %}
+    <li class="toctree-l1">
+      <a class="reference internal" href="/dotnet/api/">.NET API Reference</a>
+    </li>
+  {% endif %}
+  
+{% endblock %}
+
 {# Language picker interface #}
 {% block sidebartitle %}
   {{ super () }}


### PR DESCRIPTION
This could be easily extended for all the other languages generated API docs (javadocs, etc).

We could also move the REST-only API Reference item down to the bottom of the TOC I suppose (for consistency).
