### PR TITLE
Rewrite MCF import section for better readability

### DIFF
--- a/source/accnt_mgmt.rst
+++ b/source/accnt_mgmt.rst
@@ -1104,7 +1104,7 @@ Once the Account is created, Stormpath will use the password hash to authenticat
 .. _stormpath2-hash:
 
 The stormpath2 Format
-+++++++++++++++++++++
+"""""""""""""""""""""
 
 If your passwords are hashed with MD5 or SHA, you can import them by creating a ``$``-delimited MCF string that describes the hashing algorithm and parameters. The string should be prefixed with the token ``$stormpath2`` and must follow this format::
 


### PR DESCRIPTION
Based on a recent conversation with @robertjd and @jakubswiatczak (and @dogeared?). I rewrote parts of this section to be more clear as to what type of passwords Stormpath can import, and how to do bcrypt and stormpath2.

Let me know what y'all think.
