### PR TITLE
Fix link in forgot password email example.

### DIFF
--- a/source/accnt_mgmt.rst
+++ b/source/accnt_mgmt.rst
@@ -2322,7 +2322,7 @@ So the user would then receive something that looked like this::
 
   To reset your password please click on this link or cut and paste this
   URL into your browser (link expires in 24 hours):
-  https://api.stormpath.com/passwordReset?sptoken=eyJraWQiOiIxZ0JUbmNXc[...]
+  http://yoursite.com/path/to/reset/page?sptoken=eyJraWQiOiIxZ0JUbmNXc[...]
 
   This link takes you to a secure page where you can change your password.
 


### PR DESCRIPTION
This specifies the correct custom link in the Forgot Password email
example. Previously, the link shown was to the Stormpath API, rather
than to the user's specified custom link.