### PR TITLE
#388 Fixed Java refresh token typo

### DIFF
--- a/source/code/java/authentication/refresh_access_token_req.java
+++ b/source/code/java/authentication/refresh_access_token_req.java
@@ -1,4 +1,4 @@
-OAuthPasswordGrantRequestAuthentication request =
+OAuthRefreshTokenRequestAuthentication request =
     OAuthRequests.OAUTH_REFRESH_TOKEN_REQUEST
         .builder()
         .setRefreshToken(refreshTokenString)


### PR DESCRIPTION
https://github.com/stormpath/stormpath-documentation/issues/388

Under Refreshing Access Tokens section:

Code written:

OAuthPasswordGrantRequestAuthentication request =

Correction:

OAuthRefreshTokenRequestAuthentication request =