### PR TITLE
Add LDAP directory creation to Ruby code examples

### DIFF
--- a/source/accnt_mgmt.rst
+++ b/source/accnt_mgmt.rst
@@ -317,15 +317,12 @@ How to Make an LDAP Directory
 
 .. only:: ruby
 
-  .. warning::
+  LDAP Directories can be made using the Stormpath Admin Console, or using the Ruby SDK. If you'd like to do it with the Admin Console, please see `the Directory Creation section of the Admin Console Guide <http://docs.stormpath.com/console/product-guide/latest/directories.html#create-a-directory>`_.
 
-    This feature is not yet available in the Ruby SDK. For updates, you can follow `ticket #161 <https://github.com/stormpath/stormpath-sdk-ruby/issues/161>`_ on Github.
+  Here's how you can create a LDAP directory:
 
-    In the meantime, please use the Stormpath Admin Console. Please see `the Directory Creation section of the Admin Console Guide <http://docs.stormpath.com/console/product-guide/latest/directories.html#create-a-directory>`_ for more information.
-
-  .. todo::
-
-    Add LDAP directory creation Ruby example (ruby.todo)
+  .. literalinclude:: code/ruby/authentication/create_directory_ldap.rb
+    :language: ruby
 
 .. only:: rest or csharp or vbnet or php
 

--- a/source/auth_n.rst
+++ b/source/auth_n.rst
@@ -2381,18 +2381,8 @@ Step 1: Create an LDAP Directory
 
 .. only:: ruby
 
-  .. warning::
-
-    This feature is not yet available in the Ruby SDK. For updates, you can follow `ticket #161 <https://github.com/stormpath/stormpath-sdk-ruby/issues/161>`_ on Github.
-
-    In the meantime, please use the Stormpath Admin Console. Please see `the Agents section of the Admin Console Guide <https://docs.stormpath.com/console/product-guide/latest/agents.html#creating-an-ldap-directory>`_.
-
-  .. todo::
-
-    Add LDAP directory creation Ruby example (ruby.todo)
-
-    .. literalinclude:: code/ruby/authentication/create_directory_ldap.rb
-      :language: ruby
+  .. literalinclude:: code/ruby/authentication/create_directory_ldap.rb
+    :language: ruby
 
 .. only:: rest or vbnet or csharp or php
 

--- a/source/code/ruby/authentication/create_directory_ldap.rb
+++ b/source/code/ruby/authentication/create_directory_ldap.rb
@@ -1,0 +1,37 @@
+client.directories.create(
+  name: 'ruby ldap directory',
+  description: 'ruby ldap directory description',
+  provider: {
+    provider_id: 'ldap',
+    agent: {
+      config: {
+        directory_host: 'ldap.local',
+        directory_port: '636',
+        ssl_required: true,
+        agent_user_dn: 'tom@stormpath.com',
+        agent_user_dn_password: 'StormpathRulez',
+        base_dn: 'dc=example,dc=com',
+        poll_interval: 60,
+        account_config: {
+          dn_suffix: 'ou=employees',
+          object_class: 'person',
+          object_filter: '(cn=finance)',
+          email_rdn: 'email',
+          given_name_rdn: 'givenName',
+          middle_name_rdn: 'middleName',
+          surname_rdn: 'sn',
+          username_rdn: 'uid',
+          password_rdn: 'userPassword'
+        },
+        group_config: {
+          dn_suffix: 'ou=groups',
+          object_class: 'groupOfUniqueNames',
+          object_filter: '(ou=*-group)',
+          name_rdn: 'cn',
+          description_rdn: 'description',
+          members_rdn: 'uniqueMember'
+        }
+      }
+    }
+  }
+)

--- a/source/code/ruby/authentication/create_mapping_rule.rb
+++ b/source/code/ruby/authentication/create_mapping_rule.rb
@@ -1,6 +1,6 @@
 rule = {
-  'name' => 'uid',
-  'accountAttributes' => ['username']
+  name: 'uid',
+  account_attributes: ['username']
 }
 
 directory.attribute_statement_mapping_rules.items = [rule]


### PR DESCRIPTION
Also, I fixed a small typo with the attribute naming convention in the SAML IdP code example